### PR TITLE
ci: ignore sourcemap files in check-dist workflow

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -58,9 +58,11 @@ jobs:
             ls -la ./
             exit 1
           fi
-          if [ "$(git diff --ignore-space-at-eol --text dist/ | wc -l)" -gt "0" ]; then
+          # Ignore source map files when checking diffs to avoid spurious
+          # failures caused by non-deterministic sourcemap generation.
+          if [ "$(git diff --ignore-space-at-eol --text -- dist/ ':(exclude)dist/*.map' | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after build. See status below:"
-            git diff --ignore-space-at-eol --text dist/
+            git diff --ignore-space-at-eol --text -- dist/ ':(exclude)dist/*.map'
             exit 1
           fi
 


### PR DESCRIPTION
This pull request updates the workflow that checks for uncommitted build artifacts to prevent false positives caused by non-deterministic source map files. The main change is to exclude `.map` files from the diff check in the `.github/workflows/check-dist.yml` workflow.

**Workflow improvements:**

* Updated the build artifact check in `.github/workflows/check-dist.yml` to exclude source map files (`dist/*.map`) when comparing for uncommitted changes, reducing spurious workflow failures due to non-deterministic source map generation.